### PR TITLE
Added requirement that XDM properties always have concrete types.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,7 @@ Avoid non-semantic limits – don’t put current resource limits in the data mo
 * provide a `description` and `title` for each schema and each property
 * have the `title` at the top of the schema, so that it can be found without scrolling
 * make sure you have an example for every schema
+* all properties must have a specific type, while JSON-Schema does allow variability in types in cases like enumerations, concrete types are required in XDM
 * run `npm test` before you make a pull request
 * convention is that property names are in camelCase, when they appear in JSON
 * Acronyms and abbreviations in camelCase like ID, API, JSON are also capitalized in camelCase, such as `assetID`


### PR DESCRIPTION
It was found that with enumeration support that types can be variable. This is something that can cause great difficulties in data interoperability and code generation from JSON Schema. So to close this hole I am proposing that all properties have concrete types. 

Example of what we do not want to allow is :
Even more than that: the enum constraint can go without accompanying type constraint and contain values of different type, e.g.
{
    "$schema": "http://json-schema.org/draft-06/schema#",
    "$id": "https://ns.adobe.com/xdm/sample1", 
    "definitions": {
      "False": {
        "enum": [0, false, "false"]
      } 
    },
    "$ref": "#/definitions/False"
}

Please link to the issue #…
